### PR TITLE
Update to new kit and fix prerendering

### DIFF
--- a/packages/svemix/package.json
+++ b/packages/svemix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svemix",
-	"version": "0.3.8",
+	"version": "0.4.0",
 	"description": "The Full-Stack addition to SvelteKit. Write your server code inside svelte files, handle sessions, forms and SEO easily.",
 	"repository": {
 		"type": "git",

--- a/packages/svemix/src/lib/Form.svelte
+++ b/packages/svemix/src/lib/Form.svelte
@@ -18,7 +18,7 @@
 </script>
 
 <script lang="ts">
-	import { createEventDispatcher, onMount } from 'svelte';
+	import { createEventDispatcher } from 'svelte';
 	import { page, session } from '$app/stores';
 	import { goto } from '$app/navigation';
 
@@ -35,8 +35,8 @@
 	let magicUrl = '';
 	let thisForm: HTMLFormElement;
 
-	$: if ($page && $page.path) {
-		let actionUrl = action.length > 0 ? action : $page.path;
+	$: if ($page && $page.url.pathname) {
+		let actionUrl = action.length > 0 ? action : $page.url.pathname;
 
 		if (actionUrl.endsWith('/')) {
 			actionUrl = actionUrl.slice(0, -1);

--- a/packages/svemix/src/lib/load.ts
+++ b/packages/svemix/src/lib/load.ts
@@ -5,7 +5,7 @@ interface SvemixLoadHandler {
 }
 
 export default function loadHandler({ routesName }: SvemixLoadHandler): Load {
-	return async ({ session, page, stuff, fetch }) => {
+	return async ({ session, url, stuff, fetch, params }) => {
 		// We have to do this because SvelteKit subscribes load to session changes if done so.
 		const _accessSession = session?.something;
 

--- a/packages/vite-plugin-svemix/package.json
+++ b/packages/vite-plugin-svemix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-svemix",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "description": "The Full-Stack addition to SvelteKit. Write your server code inside svelte files, handle sessions, forms and SEO easily.",
   "repository": {
     "type": "git",

--- a/packages/vite-plugin-svemix/src/index.d.ts
+++ b/packages/vite-plugin-svemix/src/index.d.ts
@@ -1,6 +1,5 @@
 export type SvemixConfig = {
-  routes?: string;
-  prerender?: boolean;
+  prerenderAll?: boolean;
   seoDefaults?: {
     title?: string;
     description?: string;

--- a/packages/vite-plugin-svemix/src/index.js
+++ b/packages/vite-plugin-svemix/src/index.js
@@ -12,6 +12,7 @@ export default function SvemixVitePlugin(config) {
           filename: id,
           content: src,
           scripts: { arr: [] },
+          prerender: false,
           functions: { action: false, loader: false, metadata: false },
           route: {},
         },

--- a/packages/vite-plugin-svemix/src/pipeline/pipes/keywords.js
+++ b/packages/vite-plugin-svemix/src/pipeline/pipes/keywords.js
@@ -22,6 +22,13 @@ export default async function KeywordsPipe(args) {
 
   doc.functions = keywords;
 
+  // TODO: this is probably a bit to hacky...
+  if (doc.scripts.ssr.content.includes("prerender = true")) {
+    doc.prerender = true;
+  } else if (doc.scripts.ssr.content.includes("prerender = false")) {
+    doc.prerender = false;
+  }
+
   if (Object.values(doc.functions).every((value) => value === false)) {
     return {
       config,

--- a/packages/vite-plugin-svemix/src/pipeline/pipes/routes.js
+++ b/packages/vite-plugin-svemix/src/pipeline/pipes/routes.js
@@ -39,7 +39,7 @@ export default async function RoutesPipe(args) {
     if (param && param.length > 0) {
       routesName = routesName.replace(
         param[0],
-        '${page.params["' + param[1] + '"]}'
+        '${params["' + param[1] + '"]}'
       );
     }
   });

--- a/packages/vite-plugin-svemix/src/pipeline/pipes/validator.js
+++ b/packages/vite-plugin-svemix/src/pipeline/pipes/validator.js
@@ -6,10 +6,14 @@ export default async function ValidatorPipe(args) {
     seoDefaults: {
 
     },
+    prerenderAll: false,
     ...config,
-    prerender: false,
     routes: "/routes"
   };
+
+  if(config.prerenderAll){
+    doc.prerender = 'all';
+  }
 
   // Only check for files within routes
   if (!doc.filename || !doc.filename.includes(config.routes)) {

--- a/packages/vite-plugin-svemix/src/pipeline/types.d.ts
+++ b/packages/vite-plugin-svemix/src/pipeline/types.d.ts
@@ -6,6 +6,7 @@ export type PipeParsedScript = {
 export type PipeDocument = {
   filename: string;
   content: string;
+  prerender: 'all' | boolean;
   functions: {
     loader: boolean;
     metadata: boolean;


### PR DESCRIPTION
This PR enables prerendering by ignoring the url search if enabled and updates to the latest kit changes. 

-> Replace [request|page].[origin|path|query] with url object

