### PR TITLE
Svemix config file

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -27,7 +27,7 @@
 		"tailwindcss": "^3.0.8",
 		"tslib": "^2.3.1",
 		"typescript": "^4.5.4",
-		"vite-plugin-svemix": "^0.4.1"
+		"vite-plugin-svemix": "^0.4.2"
 	},
 	"dependencies": {
 		"svemix": "^0.4.2"

--- a/docs/src/routes/docs/__layout.svelte
+++ b/docs/src/routes/docs/__layout.svelte
@@ -24,6 +24,10 @@
 			{
 				title: 'Sessions',
 				href: '/docs/getting-started/session'
+			},
+			{
+				title: 'Configuration',
+				href: '/docs/getting-started/configuration'
 			}
 		]
 	};

--- a/docs/src/routes/docs/getting-started/configuration.svelte.md
+++ b/docs/src/routes/docs/getting-started/configuration.svelte.md
@@ -1,0 +1,48 @@
+---
+title: Configuration
+---
+
+<script context="module">
+	export const prerender = true;
+</script>
+<script>
+	import PostBottomNavigation from "../../../components/PostBottomNavigation.svelte";
+</script>
+
+<p class="mb-4 leading-6 font-semibold text-sky-300">Configuration</p>
+
+# {title}
+
+<br>
+
+You can provide svemix a `svemix.config.js` file inside your project root. This config file should export default a svemix config object. The configuration will be used by vite-plugin-svelte for seo and other details.
+
+### Please note: the config is pretty much still todo, there are only a few seo defaults right now. We will also make the routes/output folder configurable in the future.
+
+<br>
+
+<h2 id="example">Example</h2>
+
+<br>
+
+```js
+// svemix.config.js
+import svemix from 'vite-plugin-svemix';
+
+/** @type {import('vite-plugin-svemix').SvemixConfig} */
+const config = {
+  prerenderAll: false, // boolean
+  seo: {
+    title: "",
+    description: "",
+    keywords: "",
+  };
+};
+
+export default config;
+```
+
+<PostBottomNavigation
+previous={{ title: 'Sessions', href: '/docs/getting-started/session' }}
+next={{ title: '', href: '' }}
+/>

--- a/docs/src/routes/docs/getting-started/meta.svelte.md
+++ b/docs/src/routes/docs/getting-started/meta.svelte.md
@@ -74,26 +74,20 @@ Each `.svelte` file inside your `routes` folder can export a `metadata` function
 
 <h2 id="configuration">Configuration</h2>
 
-You can specify your default meta/seo config inside `svelte.config.js`
+You can specify your default meta/seo config inside `svemix.config.js`
 
 ```js
+// svemix.config.js
+
 import svemix from 'vite-plugin-svemix';
 
-/** @type {import('@sveltejs/kit').Config} */
+/** @type {import('vite-plugin-svemix').SvemixConfig} */
 const config = {
-	kit: {
-		vite: {
-			plugins: [
-				svemix({
-					seoDefaults: {
-						title: 'Default Title',
-						description: 'Default Description',
-						keywords: 'default,keywords,seo'
-					}
-				})
-			]
-		}
-	}
+  seo: {
+    title: "",
+    description: "",
+    keywords: "",
+  };
 };
 
 export default config;

--- a/docs/svemix.config.js
+++ b/docs/svemix.config.js
@@ -1,0 +1,6 @@
+/** @type {import('vite-plugin-svemix').SvemixConfig} */
+const config = {
+	prerenderAll: true
+};
+
+export default config;

--- a/packages/vite-plugin-svemix/package.json
+++ b/packages/vite-plugin-svemix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-svemix",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "The Full-Stack addition to SvelteKit. Write your server code inside svelte files, handle sessions, forms and SEO easily.",
   "repository": {
     "type": "git",

--- a/packages/vite-plugin-svemix/src/index.d.ts
+++ b/packages/vite-plugin-svemix/src/index.d.ts
@@ -1,10 +1,10 @@
 export type SvemixConfig = {
   prerenderAll?: boolean;
-  seoDefaults?: {
+  seo?: {
     title?: string;
     description?: string;
     keywords?: string;
   };
 };
 
-export default function SvemixVitePlugin(config: SvemixConfig): any;
+export default function SvemixVitePlugin(): any;

--- a/packages/vite-plugin-svemix/src/index.js
+++ b/packages/vite-plugin-svemix/src/index.js
@@ -1,11 +1,17 @@
+import load_config from "./load_config.js";
 import Pipeline from "./pipeline/index.js";
 
-/** @param {import('./').SvemixConfig} config */
-export default function SvemixVitePlugin(config) {
+export default function SvemixVitePlugin() {
+  let config = null;
+
   return {
     name: "vite-plugin-svemix",
     enforce: "pre",
     async transform(src, id) {
+      if (!config) {
+        config = await load_config();
+      }
+
       const result = await Pipeline({
         config,
         doc: {

--- a/packages/vite-plugin-svemix/src/internal.d.ts
+++ b/packages/vite-plugin-svemix/src/internal.d.ts
@@ -1,0 +1,5 @@
+import { SvemixConfig } from ".";
+
+export type InternalConfig = SvemixConfig & {
+  routes: string;
+};

--- a/packages/vite-plugin-svemix/src/load_config.js
+++ b/packages/vite-plugin-svemix/src/load_config.js
@@ -1,0 +1,39 @@
+import path from "path";
+import fs from "fs";
+import url from "url";
+
+/** @type {import('./internal').InternalConfig} */
+export const defaultConfig = {
+  routes: "/routes",
+  prerenderAll: false,
+  seo: {},
+};
+
+export default async function load_config({ cwd = process.cwd() } = {}) {
+  const svemix_config_file = path.join(cwd, "svemix.config.js");
+  const config_file = fs.existsSync(svemix_config_file)
+    ? svemix_config_file
+    : null;
+
+  /** @type {import('./internal').InternalConfig} */
+  let config;
+
+  if (config_file) {
+    config = await import(url.pathToFileURL(config_file).href);
+
+    if (typeof config?.default !== "object") {
+      config = defaultConfig;
+      return config;
+    }
+
+    config = {
+      ...defaultConfig,
+      ...config.default,
+    };
+  } else {
+    // Default config
+    config = defaultConfig;
+  }
+
+  return config;
+}

--- a/packages/vite-plugin-svemix/src/pipeline/pipes/routes.js
+++ b/packages/vite-plugin-svemix/src/pipeline/pipes/routes.js
@@ -9,6 +9,9 @@ export default async function RoutesPipe(args) {
   if (fileName.includes("__layout.svelte")) {
     fileName = fileName.replace("__layout.svelte", "$__layout.svelte");
   }
+  if (fileName.includes("__layout.reset.svelte")) {
+    fileName = fileName.replace("__layout.reset-svelte", "$__layout_reset.svelte");
+  }
 
   fileName = fileName.split("/");
   const extension = fileName.pop();

--- a/packages/vite-plugin-svemix/src/pipeline/pipes/transformer.js
+++ b/packages/vite-plugin-svemix/src/pipeline/pipes/transformer.js
@@ -37,7 +37,7 @@ export default async function TransformerPipe(args) {
 
   doc.content = content;
 
-  // If we have to instance, create one
+  // If we have no instance, create one
   if (!doc.scripts.instance?.content) {
     doc.content = `
      ${doc.content}

--- a/packages/vite-plugin-svemix/src/pipeline/pipes/transformers/instance.js
+++ b/packages/vite-plugin-svemix/src/pipeline/pipes/transformers/instance.js
@@ -1,7 +1,7 @@
 import { tc } from "../../utils.js";
 
 /**
- * @param {import('../../../').SvemixConfig['seoDefaults']} defaults
+ * @param {import('../../../').SvemixConfig['seo']} defaults
  * @returns {string}
  */
 const SvemixMeta = (defaults) => `
@@ -31,7 +31,7 @@ export default function InstanceTransformer(args) {
         ${doc.scripts.instance?.content || ""}
         export let _metadata = {};
     </script>
-    ${SvemixMeta(config.seoDefaults)}
+    ${SvemixMeta(config.seo)}
   `;
 
   return instanceContent;

--- a/packages/vite-plugin-svemix/src/pipeline/pipes/transformers/ssr.js
+++ b/packages/vite-plugin-svemix/src/pipeline/pipes/transformers/ssr.js
@@ -17,7 +17,7 @@ export default function SSRTransformer(args) {
 
   return `
   <script context="module">
-   ${tc(doc.functions.loader, `import { loadHandler } from "svemix"`)}
+   ${tc(doc.functions.loader || doc.functions.metadata, `import { loadHandler } from "svemix"`)}
 
    ${tc(prerenderEnabled, `export const prerender = true;`)}
    ${tc(!prerenderEnabled, `export const prerender = false;`)}
@@ -25,7 +25,7 @@ export default function SSRTransformer(args) {
    ${doc.scripts.dom?.content || ""}
 
    ${tc(
-     doc.functions.loader,
+     doc.functions.loader || doc.functions.metadata,
      `
      export async function load(input) {
       const { params } = input;
@@ -57,11 +57,11 @@ export const ssrEndpointTemplate = ({ ssrContent, doc }) => {
   ${ssrContent}
 
   ${tc(
-    doc.functions.loader,
+    doc.functions.loader || doc.functions.metadata,
     `
   export const get = getHandler({
     hasMeta: ${doc.functions.metadata},
-    loader: loader,
+    loader: ${doc.functions.loader ? 'loader' : '() => ({})'},
     metadata: ${doc.functions.metadata ? "metadata" : "() => ({})"}
   });
   `

--- a/packages/vite-plugin-svemix/src/pipeline/pipes/validator.js
+++ b/packages/vite-plugin-svemix/src/pipeline/pipes/validator.js
@@ -2,15 +2,6 @@
 export default async function ValidatorPipe(args) {
   let { config, doc } = args;
 
-  config = {
-    seoDefaults: {
-
-    },
-    prerenderAll: false,
-    ...config,
-    routes: "/routes"
-  };
-
   if(config.prerenderAll){
     doc.prerender = 'all';
   }


### PR DESCRIPTION
This PR changes the way configuration works within svemix. Users can now create a svemix.config.js file within their project root. 

Maybe the svemix config could become part of svelte.config.js later on. 

This also fixes an issue where the metadata function doesn't *execute* if no loader provided.